### PR TITLE
[#515] Fix duplicate function missing quoting steps

### DIFF
--- a/base-vm/build/jenkins/generateSecretsFile.ps1
+++ b/base-vm/build/jenkins/generateSecretsFile.ps1
@@ -262,7 +262,10 @@ Remove-Item -Force -Path 'jenkins.env.ps1'
 Foreach ($line in (Get-Content -Path "jenkins.env" | Where-Object {$_ -notmatch '^#.*'} | Where-Object {$_ -notmatch '^$'}))
 {
     # Created for sourcing for this script
-    $line -replace '^', '$' | Add-Content -Path 'jenkins.env.ps1'
+    $line -replace '^', '$' `
+    -replace '(\w+)\s=\s\x22(\S+)\x22', "`$1 = `$2" `
+    -replace '(\w+)\s=\s(\S+)', "`$1 = `"`$2`"" `
+    -replace '""""', '""' | Add-Content -Path 'jenkins.env.ps1'
 }
 
 . ./jenkins.env.ps1


### PR DESCRIPTION
Previously generated jenkins.env.ps1 currently gets overwritten when secrets are (re)generated